### PR TITLE
Update API to progressively change sim algorithm

### DIFF
--- a/chip.go
+++ b/chip.go
@@ -16,8 +16,8 @@ type chip struct {
 	w        wiring
 }
 
-func (c *chip) mount(s *Socket) []Component {
-	var updaters []Component
+func (c *chip) mount(s *Socket) []Updater {
+	var updaters []Updater
 	for i, p := range c.parts {
 		// make a sub-socket
 		sub := newSocket(s.c)

--- a/chip_test.go
+++ b/chip_test.go
@@ -78,7 +78,7 @@ func TestChip_omitted_pins(t *testing.T) {
 		Name:    "dummy",
 		Inputs:  hw.IO("a, b, c, t, f"),
 		Outputs: hw.IO("o0, o1"),
-		Mount: func(s *hw.Socket) []hw.Component {
+		Mount: func(s *hw.Socket) []hw.Updater {
 			a, b, c, tr, f, o0, o1 = s.Pin("a"), s.Pin("b"), s.Pin("c"), s.Pin("t"), s.Pin("f"), s.Pin("o0"), s.Pin("o1")
 			return nil
 		}}).NewPart

--- a/hwlib/dff.go
+++ b/hwlib/dff.go
@@ -16,16 +16,16 @@ func DFF(w string) hwsim.Part {
 		Name:    "DFF",
 		Inputs:  []string{pIn},
 		Outputs: []string{pOut},
-		Mount: func(s *hwsim.Socket) []hwsim.Component {
+		Mount: func(s *hwsim.Socket) []hwsim.Updater {
 			in, out := s.Pin(pIn), s.Pin(pOut)
 			var curOut bool
-			return []hwsim.Component{
+			return hwsim.UpdaterFn(
 				func(c *hwsim.Circuit) {
 					// raising edge?
 					if c.AtTick() {
 						curOut = c.Get(in)
 					}
 					c.Set(out, curOut)
-				}}
+				})
 		}}).NewPart(w)
 }

--- a/hwlib/dff_test.go
+++ b/hwlib/dff_test.go
@@ -1,11 +1,16 @@
-package hwsim_test
+package hwlib_test
 
 import (
+	"math/rand"
 	"testing"
 
 	hw "github.com/db47h/hwsim"
 	hl "github.com/db47h/hwsim/hwlib"
 )
+
+func randBool() bool {
+	return rand.Int63()&(1<<62) != 0
+}
 
 func TestDFF(t *testing.T) {
 	var (

--- a/hwlib/io.go
+++ b/hwlib/io.go
@@ -19,15 +19,10 @@ func Input(f func() bool) hwsim.NewPartFn {
 		Name:    "Input",
 		Inputs:  nil,
 		Outputs: []string{pOut},
-		Mount: func(s *hwsim.Socket) []hwsim.Component {
+		Mount: func(s *hwsim.Socket) []hwsim.Updater {
 			pin := s.Pin(pOut)
-			return []hwsim.Component{
-				func(c *hwsim.Circuit) {
-					c.Set(pin, f())
-				},
-			}
-		},
-	}
+			return hwsim.UpdaterFn(func(c *hwsim.Circuit) { c.Set(pin, f()) })
+		}}
 	return p.NewPart
 }
 
@@ -42,13 +37,10 @@ func Output(f func(bool)) hwsim.NewPartFn {
 		Name:    "Output",
 		Inputs:  []string{pIn},
 		Outputs: nil,
-		Mount: func(s *hwsim.Socket) []hwsim.Component {
+		Mount: func(s *hwsim.Socket) []hwsim.Updater {
 			in := s.Pin(pIn)
-			return []hwsim.Component{
-				func(c *hwsim.Circuit) { f(c.Get(in)) },
-			}
-		},
-	}
+			return hwsim.UpdaterFn(func(c *hwsim.Circuit) { f(c.Get(in)) })
+		}}
 	return p.NewPart
 }
 
@@ -59,11 +51,11 @@ func InputN(bits int, f func() int64) hwsim.NewPartFn {
 		Name:    "INPUT" + strconv.Itoa(bits),
 		Inputs:  nil,
 		Outputs: bus(bits, pOut),
-		Mount: func(s *hwsim.Socket) []hwsim.Component {
+		Mount: func(s *hwsim.Socket) []hwsim.Updater {
 			pins := s.Bus(pOut, bits)
-			return []hwsim.Component{func(c *hwsim.Circuit) {
+			return hwsim.UpdaterFn(func(c *hwsim.Circuit) {
 				c.SetInt64(pins, f())
-			}}
+			})
 		}}).NewPart
 }
 
@@ -74,10 +66,10 @@ func OutputN(bits int, f func(int64)) hwsim.NewPartFn {
 		Name:    "OUTPUTBUS" + strconv.Itoa(bits),
 		Inputs:  bus(bits, pIn),
 		Outputs: nil,
-		Mount: func(s *hwsim.Socket) []hwsim.Component {
+		Mount: func(s *hwsim.Socket) []hwsim.Updater {
 			pins := s.Bus(pIn, bits)
-			return []hwsim.Component{func(c *hwsim.Circuit) {
+			return hwsim.UpdaterFn(func(c *hwsim.Circuit) {
 				f(c.GetInt64(pins))
-			}}
+			})
 		}}).NewPart
 }

--- a/reflect.go
+++ b/reflect.go
@@ -95,8 +95,8 @@ func MakePart(t Updater) *PartSpec {
 	return sp
 }
 
-func mountPart(typ reflect.Type) func(s *Socket) []Component {
-	return func(s *Socket) []Component {
+func mountPart(typ reflect.Type) func(s *Socket) []Updater {
+	return func(s *Socket) []Updater {
 		v := reflect.New(typ)
 		e := v.Elem()
 		n := typ.NumField()
@@ -135,8 +135,6 @@ func mountPart(typ reflect.Type) func(s *Socket) []Component {
 		}
 
 		comp := v.Interface().(Updater)
-		return []Component{
-			comp.Update,
-		}
+		return []Updater{comp}
 	}
 }


### PR DESCRIPTION
Affects #14, #9

Workers have been disabled:

A 16 bits carry-lookahead adder with 553 NANDs runs at 1204Hz with workers, 4800, without (32 ticks per clock cycle). Let's drop the added complexity for now.
